### PR TITLE
Add quick-start script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ GoReportCard Lite, a slim version of original [Go Report Card](https://github.co
 
 A web application that generates a report on the quality of go project. It uses several measures, including `gofmt`, `go vet`, `go lint` and `gocyclo`.
 
+### Quick start
+If you have Docker installed and want to analyze a local project, just navigate to that project and run:
+
+```sh
+curl -s https://raw.githubusercontent.com/nearmap/goreportcardlite/master/analyze_current_directory.sh | bash
+```
+
+or, you can save [this script](analyze_current_directory.sh) to your PATH, and run it, still from the project you want to analyze.
+
 ### Installation
 
 Assuming you already have a recent version of Go installed, pull down the code with `go get`:

--- a/analyze_current_directory.sh
+++ b/analyze_current_directory.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script will run a set of Go static analysis tools against a local project and collect results into an HTML file.
+
+# Ensure we are on a valid Go project
+if [ -z "${GOPATH}" ]; then
+    echo "ERROR: GOPATH environment variable not defined"
+    exit 1
+fi
+
+project_dir=$(pwd)
+
+if ! [[ ${project_dir} == ${GOPATH}/src/* ]]; then
+    echo "ERROR: The current directory does not correspond to a valid Go project"
+    exit 1
+fi
+
+# Get the analysis done
+project_name=${project_dir#${GOPATH}/src/}
+echo "Analyzing local checkout of \"${project_name}\"... this will take a minute"
+
+docker run -v ${project_dir}:/go/src/${project_name} nearmap/goreportcard ${project_name}
+
+# Report result
+if [[ $? == 0 ]]; then
+    echo "Report was successfully generated -> goreportcard.html"
+else
+    echo "ERROR: Something went wrong."
+fi


### PR DESCRIPTION
This changes introduces (and documents) a shell script `analyze_current_directory.sh` which has the intent of simplifying the most common use case of this project.

In fact, a Go developer who just wants to analyse his local project does not necessarily want to be exposed to running an HTTP server or figuring out the right arguments for a `docker run` command.

The script proposed with this PR takes care of all of this, hopefully making a one-shot project analysis a no-brainer.